### PR TITLE
Add Flexible Checksum v2 Config Options

### DIFF
--- a/botocore/config.py
+++ b/botocore/config.py
@@ -235,6 +235,37 @@ class Config:
         specified service will be ignored.
 
         Defaults to None.
+
+    :type request_checksum_calculation: ``RequestChecksumCalculation``
+    :param request_checksum_calculation: Determines when a checksum will be
+        calculated for request payloads. Valid values are:
+
+        * ``WHEN_SUPPORTED`` -- When set, a checksum will be calculated for
+            all request payloads of operations modeled with the ``httpChecksum``
+            trait where ``requestChecksumRequired`` is ``true`` and/or a
+            ``requestAlgorithmMember`` is modeled.
+
+        * ``WHEN_REQUIRED`` -- When set, a checksum will only be calculated
+            for request payloads of operations modeled with the ``httpChecksum``
+            trait where ``requestChecksumRequired`` is ``true`` or where a
+            ``requestAlgorithmMember`` is modeled and supplied.
+
+        Defaults to None.
+
+    :type response_checksum_validation: ``ResponseChecksumValidation``
+    :param response_checksum_validation: Determines when checksum validation
+        will be performed on response payloads. Valid values are:
+
+        * ``WHEN_SUPPORTED`` -- When set, checksum validation is performed on
+            all response payloads of operations modeled with the ``httpChecksum``
+            trait where ``responseAlgorithms`` is modeled, except when no modeled
+            checksum algorithms are supported.
+
+        * ``WHEN_REQUIRED`` -- When set, checksum validation is not performed
+            on response payloads of operations unless the checksum algorithm is
+            supported and the ``requestValidationModeMember`` member is set to ``ENABLED``.
+
+        Defaults to None.
     """
 
     OPTION_DEFAULTS = OrderedDict(
@@ -264,6 +295,8 @@ class Config:
             ('disable_request_compression', None),
             ('client_context_params', None),
             ('sigv4a_signing_region_set', None),
+            ('request_checksum_calculation', None),
+            ('response_checksum_validation', None),
         ]
     )
 

--- a/botocore/configprovider.py
+++ b/botocore/configprovider.py
@@ -168,6 +168,18 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
         None,
         None,
     ),
+    'request_checksum_calculation': (
+        'request_checksum_calculation',
+        'AWS_REQUEST_CHECKSUM_CALCULATION',
+        "when_supported",
+        None,
+    ),
+    'response_checksum_validation': (
+        'response_checksum_validation',
+        'AWS_RESPONSE_CHECKSUM_VALIDATION',
+        "when_supported",
+        None,
+    ),
 }
 
 # Evaluate AWS_STS_REGIONAL_ENDPOINTS settings
@@ -468,7 +480,7 @@ class ConfigValueStore:
 
     def get_config_variable(self, logical_name):
         """
-        Retrieve the value associeated with the specified logical_name
+        Retrieve the value associated with the specified logical_name
         from the corresponding provider. If no value is found None will
         be returned.
 

--- a/botocore/exceptions.py
+++ b/botocore/exceptions.py
@@ -814,3 +814,12 @@ class EndpointResolutionError(EndpointProviderError):
 
 class UnknownEndpointResolutionBuiltInName(EndpointProviderError):
     fmt = 'Unknown builtin variable name: {name}'
+
+
+class InvalidChecksumConfigError(BotoCoreError):
+    """Error when invalid value supplied for checksum config"""
+
+    fmt = (
+        'Unsupported configuration value for {config_key}. '
+        'Expected one of {valid_options} but got {config_value}.'
+    )

--- a/botocore/httpchecksum.py
+++ b/botocore/httpchecksum.py
@@ -23,6 +23,7 @@ import base64
 import io
 import logging
 from binascii import crc32
+from enum import Enum
 from hashlib import sha1, sha256
 
 from botocore.compat import HAS_CRT
@@ -43,6 +44,24 @@ else:
     crt_checksums = None
 
 logger = logging.getLogger(__name__)
+
+
+class ResponseChecksumValidation(str, Enum):
+    WHEN_SUPPORTED = "when_supported"
+    WHEN_REQUIRED = "when_required"
+
+    @classmethod
+    def values(cls):
+        return tuple(member.value for member in cls)
+
+
+class RequestChecksumCalculation(str, Enum):
+    WHEN_SUPPORTED = "when_supported"
+    WHEN_REQUIRED = "when_required"
+
+    @classmethod
+    def values(cls):
+        return tuple(member.value for member in cls)
 
 
 class BaseChecksum:

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -614,6 +614,70 @@ class TestCreateClientArgs(unittest.TestCase):
         config = client_args['client_config']
         self.assertFalse(config.disable_request_compression)
 
+    def test_checksum_default_client_config(self):
+        input_config = Config()
+        client_args = self.call_get_client_args(client_config=input_config)
+        config = client_args["client_config"]
+        self.assertEqual(config.request_checksum_calculation, "when_supported")
+        self.assertEqual(config.response_checksum_validation, "when_supported")
+
+    def test_checksum_client_config(self):
+        input_config = Config(
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+        )
+        client_args = self.call_get_client_args(client_config=input_config)
+        config = client_args['client_config']
+        self.assertEqual(config.request_checksum_calculation, "when_required")
+        self.assertEqual(config.response_checksum_validation, "when_required")
+
+    def test_checksum_config_store(self):
+        self.config_store.set_config_variable(
+            "request_checksum_calculation", "when_required"
+        )
+        self.config_store.set_config_variable(
+            "response_checksum_validation", "when_required"
+        )
+        config = self.call_get_client_args()['client_config']
+        self.assertEqual(config.request_checksum_calculation, "when_required")
+        self.assertEqual(config.response_checksum_validation, "when_required")
+
+    def test_checksum_client_config_overrides_config_store(self):
+        self.config_store.set_config_variable(
+            "request_checksum_calculation", "when_supported"
+        )
+        self.config_store.set_config_variable(
+            "response_checksum_validation", "when_supported"
+        )
+        input_config = Config(
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+        )
+        client_args = self.call_get_client_args(client_config=input_config)
+        config = client_args['client_config']
+        self.assertEqual(config.request_checksum_calculation, "when_required")
+        self.assertEqual(config.response_checksum_validation, "when_required")
+
+    def test_request_checksum_calculation_invalid_client_config(self):
+        with self.assertRaises(exceptions.InvalidChecksumConfigError):
+            config = Config(request_checksum_calculation="invalid_config")
+            self.call_get_client_args(client_config=config)
+        self.config_store.set_config_variable(
+            'request_checksum_calculation', "invalid_config"
+        )
+        with self.assertRaises(exceptions.InvalidChecksumConfigError):
+            self.call_get_client_args()
+
+    def test_response_checksum_validation_invalid_client_config(self):
+        with self.assertRaises(exceptions.InvalidChecksumConfigError):
+            config = Config(response_checksum_validation="invalid_config")
+            self.call_get_client_args(client_config=config)
+        self.config_store.set_config_variable(
+            'response_checksum_validation', "invalid_config"
+        )
+        with self.assertRaises(exceptions.InvalidChecksumConfigError):
+            self.call_get_client_args()
+
 
 class TestEndpointResolverBuiltins(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Overview
This PR adds the ``request_checksum_calculation`` and ``response_checksum_validation`` config options. 

> [!NOTE]  
> This PR only implements the functionality to configure the new options and doesn't actually use them for anything yet.

## Request Checksum Calculation
A new configuration option will be introduced that allows users to configure request checksum calculation behavior. The following configuration methods will be supported:

* Environment Variable - ``AWS_REQUEST_CHECKSUM_CALCULATION``
* Profile Config - ``request_checksum_calculation``
* Client Config - ``request_checksum_calculation``

Supported values:

* ``WHEN_SUPPORTED`` (Default) - If operations are modeled with  ``"requestChecksumRequired":true`` OR a ``requestAlgorithmMember``, then a checksum will be calculated for all request payloads.
* ``WHEN_REQUIRED`` - If operations are modeled with  ``"requestChecksumRequired":true`` or ``requestAlgorithmMember`` is modeled and set by the user, then a checksum will be calculated for request payloads.


## Response Checksum Validation
A new configuration option will be introduced that allows users to configure response checksum validation behavior. The following configuration methods will be supported:

* Environment Variable - ``AWS_RESPONSE_CHECKSUM_VALIDATION``
* Profile Config - ``response_checksum_validation``
* Client Config - ``response_checksum_validation``

Supported Values:

* ``WHEN_SUPPORTED`` (Default) - Checksum validation MUST be performed on all response payloads for operations modeled with the ``responseAlgorithms`` trait, unless no modeled checksum is supported.
* ``WHEN_REQUIRED`` - Checksum validation MUST NOT be performed on response payloads of operations UNLESS botocore supports the modeled checksum algorithms AND the user has set the ``requestValidationMemeber`` to ``ENABLED``. 

